### PR TITLE
Updated NewModule-example with v2.0 tasks.json

### DIFF
--- a/examples/NewModule/editor/VSCode/tasks_pester.json
+++ b/examples/NewModule/editor/VSCode/tasks_pester.json
@@ -9,40 +9,45 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "0.1.0",
+    "version": "2.0.0",
 
-	// Start PowerShell
+    // Start PowerShell
     "windows": {
-        "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
-        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
+        "options": {
+            "shell": {
+                "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
+            }
+        }
     },
     "linux": {
-        "command": "/usr/bin/pwsh",
-        "args": [ "-NoProfile" ]
+        "options": {
+            "shell": {
+                "executable": "/usr/bin/pwsh",
+                "args": [ "-NoProfile", "-Command" ]
+            }
+        }
     },
     "osx": {
-        "command": "/usr/local/bin/pwsh",
-        "args": [ "-NoProfile" ]
+        "options": {
+            "shell": {
+                "executable": "/usr/local/bin/pwsh",
+                "args": [ "-NoProfile", "-Command" ]
+            }
+        }
     },
-
-	// The command is a shell script
-	"isShellCommand": true,
-
-	// Show the output window always
-	"showOutput": "always",
 
     // Associate with test task runner
     "tasks": [
         {
-            "taskName": "Test",
-            "suppressTaskName": true,
-            "isTestCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking Pester...'; $ProgressPreference = 'SilentlyContinue'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
-                "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
-            ],
-            "problemMatcher": "$pester"
+            "label": "Test",
+            "type": "shell",
+            "command": "Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true}",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": [ "$pester" ]
         }
 	]
 }

--- a/examples/NewModule/editor/VSCode/tasks_psake.json
+++ b/examples/NewModule/editor/VSCode/tasks_psake.json
@@ -9,84 +9,75 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "0.1.0",
+    "version": "2.0.0",
 
-	// Start PowerShell
+    // Start PowerShell
     "windows": {
-        "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
-        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
+        "options": {
+            "shell": {
+                "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
+            }
+        }
     },
     "linux": {
-        "command": "/usr/bin/powershell",
-        "args": [ "-NoProfile" ]
+        "options": {
+            "shell": {
+                "executable": "/usr/bin/pwsh",
+                "args": [ "-NoProfile", "-Command" ]
+            }
+        }
     },
     "osx": {
-        "command": "/usr/local/bin/powershell",
-        "args": [ "-NoProfile" ]
+        "options": {
+            "shell": {
+                "executable": "/usr/local/bin/pwsh",
+                "args": [ "-NoProfile", "-Command" ]
+            }
+        }
     },
-
-	// The command is a shell script
-	"isShellCommand": true,
-
-	// Show the output window always
-	"showOutput": "always",
 
     // Associate with test task runner
     "tasks": [
         {
-            "taskName": "Clean",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Clean'; Invoke-psake build.psake.ps1 -taskList Clean;",
-                "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
-            ]
+            "label": "Clean",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Clean",
+            "problemMatcher": []
         },
         {
-            "taskName": "Build",
-            "suppressTaskName": true,
-            "isBuildCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Build'; Invoke-psake build.psake.ps1 -taskList Build;",
-                "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
-            ]
+            "label": "Build",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
         },
         {
-            "taskName": "BuildHelp",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList BuildHelp'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
-                "Invoke-Command { Write-Host 'Completed BuildHelp task in task runner.' }"
-            ]
+            "label": "BuildHelp",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList BuildHelp",
+            "problemMatcher": []
         },
         {
-            "taskName": "Analyze",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Analyze'; Invoke-psake build.psake.ps1 -taskList Analyze;",
-                "Invoke-Command { Write-Host 'Completed Analyze task in task runner.' }"
-            ]
+            "label": "Analyze",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Analyze",
+            "problemMatcher": []
         },
         {
-            "taskName": "Install",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Install'; Invoke-psake build.psake.ps1 -taskList Install;",
-                "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
-            ]
+            "label": "Install",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Install",
+            "problemMatcher": []
         },
         {
-            "taskName": "Publish",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Publish'; Invoke-psake build.psake.ps1 -taskList Publish;",
-                "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
-            ]
+            "label": "Publish",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Publish",
+            "problemMatcher": []
         }
 	]
 }

--- a/examples/NewModule/editor/VSCode/tasks_psake_pester.json
+++ b/examples/NewModule/editor/VSCode/tasks_psake_pester.json
@@ -9,112 +9,85 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "0.1.0",
+    "version": "2.0.0",
 
-	// Start PowerShell
+    // Start PowerShell
     "windows": {
-        "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
-        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
+        "options": {
+            "shell": {
+                "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
+            }
+        }
     },
     "linux": {
-        "command": "/usr/bin/pwsh",
-        "args": [ "-NoProfile" ]
+        "options": {
+            "shell": {
+                "executable": "/usr/bin/pwsh",
+                "args": [ "-NoProfile", "-Command" ]
+            }
+        }
     },
     "osx": {
-        "command": "/usr/local/bin/pwsh",
-        "args": [ "-NoProfile" ]
+        "options": {
+            "shell": {
+                "executable": "/usr/local/bin/pwsh",
+                "args": [ "-NoProfile", "-Command" ]
+            }
+        }
     },
-
-	// The command is a shell script
-	"isShellCommand": true,
-
-	// Show the output window always
-	"showOutput": "always",
 
     // Associate with test task runner
     "tasks": [
         {
-            "taskName": "Clean",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Clean'; Invoke-psake build.psake.ps1 -taskList Clean;",
-                "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
-            ]
+            "label": "Clean",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Clean",
+            "problemMatcher": []
         },
         {
-            "taskName": "Build",
-            "suppressTaskName": true,
-            "isBuildCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Build'; Invoke-psake build.psake.ps1 -taskList Build;",
-                "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
-            ]
+            "label": "Build",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
         },
         {
-            "taskName": "BuildHelp",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList BuildHelp'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
-                "Invoke-Command { Write-Host 'Completed BuildHelp task in task runner.' }"
-            ]
+            "label": "BuildHelp",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList BuildHelp",
+            "problemMatcher": []
         },
         {
-            "taskName": "Analyze",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Analyze'; Invoke-psake build.psake.ps1 -taskList Analyze;",
-                "Invoke-Command { Write-Host 'Completed Analyze task in task runner.' }"
-            ]
+            "label": "Analyze",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Analyze",
+            "problemMatcher": []
         },
         {
-            "taskName": "Install",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Install'; Invoke-psake build.psake.ps1 -taskList Install;",
-                "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
-            ]
+            "label": "Install",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Install",
+            "problemMatcher": []
         },
         {
-            "taskName": "Publish",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Publish'; Invoke-psake build.psake.ps1 -taskList Publish;",
-                "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
-            ]
+            "label": "Publish",
+            "type": "shell",
+            "command": "Invoke-psake build.psake.ps1 -taskList Publish",
+            "problemMatcher": []
         },
         {
-            "taskName": "Test",
-            "suppressTaskName": true,
-            "isTestCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking Pester'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
-                "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
-            ],
-            "problemMatcher": [
-                {
-                    "owner": "powershell",
-                    "fileLocation": ["absolute"],
-                    "severity": "error",
-                    "pattern": [
-                        {
-                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
-                            "message": 1
-                        },
-                        {
-                            "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
-                            "file": 1,
-                            "line": 2
-                        }
-                    ]
-                }
-            ]
+            "label": "Test",
+            "type": "shell",
+            "command": "Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true}",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": [ "$pester" ]
         }
 	]
 }


### PR DESCRIPTION
NewModule-example still used 0.1.0 schema for VSCode tasks.json including the `"isShellCommand": true`-bug that was fixed in #257 . Updated remaining tasks.json to 2.0.0 schema.