### PR TITLE
Adding File Substitution for Modify Content Element

### DIFF
--- a/docs/en-US/about_Plaster_CreatingAManifest.help.md
+++ b/docs/en-US/about_Plaster_CreatingAManifest.help.md
@@ -304,6 +304,7 @@ Available attributes for this content element are:
         - `expand` - Whether to expand variables within the original for match.
     - `substitute` - The replacement text to substitute in place of the original text.
         - `expand` - Whether to expand variables within the substitute text.
+        - `isFile` - Specifies `substitute` to be a relative filename. Reads file content. Cannot be used with `expand`.
     - `condition`
 - `path`         - Specifies the relative path, under the destination folder, of the file to be modified.
 - `encoding`     - Specifies the encoding of the file, see `Content Element: Common` for possible values. If you do not specify an encoding, ASCII encoding will be used.

--- a/src/Schema/PlasterManifest-v1.xsd
+++ b/src/Schema/PlasterManifest-v1.xsd
@@ -250,6 +250,11 @@
               <xs:documentation>If true, expands variables in the replacement string, as if the string were a double quoted PowerShell string.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="isFile" type="xs:boolean" default="false">
+            <xs:annotation>
+              <xs:documentation>If true, reads the substitute as a file.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
Added ability to substitute whole files into Modify content element.

By specifying isFile="true", Invoke-Plaster will load and substitute an entire file into the variable. See example below:

```
            <replace condition="$PLASTER_PARAM_Custom_LoggingType -eq 'AppInsights'">
              <original>#PLASTER_Snippet_PSScript_Code_Main_Logging#</original>
              <substitute isFile='true'>.\SupportingDirectories\Template\PSSnippets\Snippet_PSScript_Code_Main_Logging.ps1</substitute>
            </replace>
```