### PR TITLE
Text parameter using default value always returns default value if condition is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Changed
 
 - Updated PSScriptAnalyzerSettings.psd1 template file to sync w/latest in vscode-powershell examples.
+- Text parameter with default value where condition evaluates to false returns default value.
 
 ## 1.1.1 - 2017-10-26
 

--- a/test/InvokePlaster.Tests.ps1
+++ b/test/InvokePlaster.Tests.ps1
@@ -101,5 +101,38 @@ Describe 'Invoke-Plaster Tests' {
             $res.MissingModules.Count | Should -Be 0
             @($res.OpenFiles)[0] | Should -Be "$DestPath\foo.txt"
         }
+
+        It 'Text parameter with default value where condition evaluates to false returns default value' {
+            CleanDir $TemplateDir
+            CleanDir $OutDir
+
+@'
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="1.1" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <name>TemplateName</name>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <version>0.2.0</version>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <tags></tags>
+    </metadata>
+    <parameters>
+        <parameter name='TestParameter' default="MyValue" condition="$false" type='text' prompt='Enter string value' />
+    </parameters>
+    <content>
+        <file condition="$PLASTER_PARAM_TestParameter -ne $null" source='Recurse\foo.txt' destination='foo.txt'/>
+    </content>
+</plasterManifest>
+'@ | Out-File $PlasterManifestPath -Encoding utf8
+
+            Copy-Item $PSScriptRoot\Recurse $TemplateDir -Recurse
+
+            $DestPath = Join-Path $OutDir Foo
+
+            Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $DestPath -NoLogo 6> $null
+
+            Test-Path -LiteralPath $DestPath\foo.txt | Should -Be $true
+        }
     }
 }


### PR DESCRIPTION
- Text parameter with default value where condition evaluates to false returns default value.

Fixes gaelcolas/Sampler#121

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/plaster/359)
<!-- Reviewable:end -->
