### PR TITLE
test: 🧪 Update mock implementation in `Get-ModuleExtension` tests

### DIFF
--- a/tests/Get-ModuleExtension.Tests.ps1
+++ b/tests/Get-ModuleExtension.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Get-PlasterManifestPathForCulture' {
     InModuleScope $env:BHProjectName {
         BeforeEach {
             Mock Get-Module {
-                Get-Content -Raw $PSScriptRoot\Fixtures\ModuleList.xml | ConvertFrom-CliXml
+                Import-Clixml $PSScriptRoot\Fixtures\ModuleList.xml
             }
         }
 


### PR DESCRIPTION
* Changed the mock for `Get-Module` to use `Import-Clixml` for better clarity and consistency.
* This improves the readability of the test setup and aligns with the expected data handling.