### PR TITLE
Add TemplateName parameter to Invoke-Plaster with argument completer

### DIFF
--- a/Plaster/Plaster.psm1
+++ b/Plaster/Plaster.psm1
@@ -171,5 +171,25 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
     Remove-Variable -Name 'ParameterDefaultValueStoreRootPath' -Scope Script -ErrorAction SilentlyContinue
 }
 
+# Register argument completers
+Register-ArgumentCompleter -CommandName Invoke-Plaster -ParameterName TemplateName -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    # Trim single, or double quotes from the start/end of the word to complete.
+    if ($wordToComplete -match '^[''"]') {
+        $wordToComplete = $wordToComplete.Trim($Matches.Values[0])
+    }
+
+    # Get all unique names starting with the characters provided, if any.
+    Get-PlasterTemplate -Name "$wordToComplete*" | Select-Object Name -Unique | ForEach-Object {
+        # Wrap the completion in single quotes if it contains any whitespace.
+        if ($_.Name -match '\s') {
+            "'{0}'" -f $_.Name
+        } else {
+            $_.Name
+        }
+    }
+}
+
 # Module initialization complete
 Write-PlasterLog -Level Information -Message "Plaster v$PlasterVersion module loaded successfully (PowerShell $($PSVersionTable.PSVersion))"

--- a/Plaster/Public/Invoke-Plaster.ps1
+++ b/Plaster/Public/Invoke-Plaster.ps1
@@ -27,6 +27,11 @@ function Invoke-Plaster {
         [string]
         $TemplateDefinition,
 
+        [Parameter(Position = 0, Mandatory = $true, ParameterSetName = 'TemplateName')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $TemplateName,
+
         [Parameter(Position = 1, Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -69,6 +74,10 @@ function Invoke-Plaster {
             we are not building up multiple parametersets. And no need for
             EvaluateAttributeValue since we are only grabbing the parameter's
             value which is static.#>
+
+            if ($PSCmdlet.ParameterSetName -eq 'TemplateName') {
+                $TemplatePath = (Get-PlasterTemplate -Name $TemplateName).TemplatePath
+            }
 
             $templateAbsolutePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($TemplatePath)
 
@@ -194,7 +203,10 @@ function Invoke-Plaster {
         #endregion Script Scope Variables
 
         # Determine template source and type
-        if ($PSCmdlet.ParameterSetName -eq 'TemplatePath') {
+        if ($PSCmdlet.ParameterSetName -eq 'TemplateName') {
+            $TemplatePath = (Get-PlasterTemplate -Name $TemplateName).TemplatePath
+        }
+        if ($PSCmdlet.ParameterSetName -in @('TemplatePath', 'TemplateName')) {
             $templateAbsolutePath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($TemplatePath)
             if (!(Test-Path -LiteralPath $templateAbsolutePath -PathType Container)) {
                 throw ($LocalizedData.ErrorTemplatePathIsInvalid_F1 -f $templateAbsolutePath)

--- a/docs/en-US/Invoke-Plaster.md
+++ b/docs/en-US/Invoke-Plaster.md
@@ -159,12 +159,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TemplatePath
-Specifies the path to the template directory.
+### -TemplateName
+
+Specifies the name of an available plaster template. Use Get-PlasterTemplate to
+list the available templates.
 
 ```yaml
 Type: String
-Parameter Sets: TemplatePath
+Parameter Sets: TemplateName
 Aliases:
 
 Required: True
@@ -174,14 +176,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TemplateName
-
-Specifies the name of an available plaster template. Use Get-PlasterTemplate to
-list the available templates.
+### -TemplatePath
+Specifies the path to the template directory.
 
 ```yaml
 Type: String
-Parameter Sets: TemplateName
+Parameter Sets: TemplatePath
 Aliases:
 
 Required: True

--- a/docs/en-US/Invoke-Plaster.md
+++ b/docs/en-US/Invoke-Plaster.md
@@ -24,6 +24,12 @@ Invoke-Plaster [-TemplateDefinition] <String> [-DestinationPath] <String> [-Forc
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### TemplateName
+```
+Invoke-Plaster [-TemplateName] <String> [-DestinationPath] <String> [-Force] [-NoLogo] [-PassThru]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Invokes the specified Plaster template which will scaffold out a file or a
 set of files and directories.
@@ -159,6 +165,23 @@ Specifies the path to the template directory.
 ```yaml
 Type: String
 Parameter Sets: TemplatePath
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateName
+
+Specifies the name of an available plaster template. Use Get-PlasterTemplate to
+list the available templates.
+
+```yaml
+Type: String
+Parameter Sets: TemplateName
 Aliases:
 
 Required: True


### PR DESCRIPTION
This PR is purely a convenience change which makes it possible to skip using `Get-PlasterTemplate` and instead use the `-TemplateName` parameter and tab through the available options.

This...

```powershell
$template = Get-PlasterTemplate | Where-Object Name -eq NewPowerShellModule
Invoke-Plaster -TemplatePath $template.TemplatePath -DestinationPath .\MyNewModule
```

Becomes this...

```powershell
Invoke-Plaster -TemplateName NewPowerShellModule -DestinationPath .\MyNewModule
```