### PR TITLE
fix: resolve Import-Module failure on PowerShell 7.4 (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-05-25
+
+### Fixed
+
+- `Import-Module Plaster` fails on PowerShell 7.4 with "not a valid
+  PowerShell module manifest file" error — the module called
+  `Test-ModuleManifest` on its own manifest during initialization,
+  causing a re-entrant validation loop that PS 7.4's stricter guards
+  reject. Replaced with `$MyInvocation.MyCommand.Module.Version`
+  ([#454](https://github.com/PowerShellOrg/Plaster/issues/454))
+
 ## [2.1.0] - 2026-05-25
 
 ### Added

--- a/Plaster/Plaster.psd1
+++ b/Plaster/Plaster.psd1
@@ -6,7 +6,7 @@
     GUID = 'cfce3c5e-402f-412a-a83a-7b7ee9832ff4'
 
     # Version number of this module.
-    ModuleVersion = '2.1.0'
+    ModuleVersion = '2.1.1'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop', 'Core')

--- a/Plaster/Plaster.psm1
+++ b/Plaster/Plaster.psm1
@@ -77,7 +77,7 @@ try {
 
 # Module variables with proper scoping and type safety
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$PlasterVersion = $MyInvocation.MyCommand.Module.Version
+$PlasterVersion = (Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot 'Plaster.psd1')).ModuleVersion
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $JsonSchemaPath = Join-Path $PSScriptRoot "Schema\plaster-manifest-v2.json"

--- a/Plaster/Plaster.psm1
+++ b/Plaster/Plaster.psm1
@@ -77,7 +77,7 @@ try {
 
 # Module variables with proper scoping and type safety
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$PlasterVersion = (Test-ModuleManifest -Path (Join-Path $PSScriptRoot 'Plaster.psd1')).Version
+$PlasterVersion = $MyInvocation.MyCommand.Module.Version
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $JsonSchemaPath = Join-Path $PSScriptRoot "Schema\plaster-manifest-v2.json"


### PR DESCRIPTION
## Summary

- `Import-Module Plaster` fails on PowerShell 7.4 with "The module manifest 'Plaster.psm1' could not be processed because it is not a valid PowerShell module manifest file"
- Root cause: `Plaster.psm1` called `Test-ModuleManifest` on its own manifest during initialization, creating a re-entrant validation loop. PS 7.4 added stricter guards that reject this circular pattern; earlier versions were permissive.
- Fix: replace `Test-ModuleManifest` with `Import-PowerShellDataFile`, which reads the psd1 as a plain hashtable without triggering module validation — no re-entrancy, no circular reference, and works whether the module is loaded via manifest or directly via psm1 path.

Fixes #454. Bumps to **2.1.1**.

## Test plan

- [ ] `Import-Module Plaster -RequiredVersion 2.1.1` succeeds on PS 7.4
- [ ] `(Get-Module Plaster).Version` returns `2.1.1`
- [ ] Log line shows `Plaster v2.1.1 module loaded successfully` (not blank)
- [x] Existing Pester suite passes (`Invoke-psake Test`)

Generated with [Claude Code](https://claude.com/claude-code)