### PR TITLE
fix: use CultureInfo ctor instead of Get-Culture -Name for PS5.1 compat

### DIFF
--- a/tests/Get-PlasterManifestPathForCulture.Tests.ps1
+++ b/tests/Get-PlasterManifestPathForCulture.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Get-PlasterManifestPathForCulture' {
   Context "when given a template path and culture" {
     InModuleScope $env:BHProjectName {
       It "returns the manifest for the specified culture" {
-        $culture = Get-Culture -name "en-US"
+        $culture = New-Object System.Globalization.CultureInfo("en-US")
         $plasterManifestFilename = "plasterManifest_en-US.xml"
         Mock -CommandName 'Test-Path' -MockWith { $true } -ParameterFilter { $Path -like "*$($script:examplesPath)" }
         $manifestPath = Get-PlasterManifestPathForCulture -TemplatePath $script:examplesPath -Culture $culture


### PR DESCRIPTION
Closes #459

## Summary

- `Get-Culture -Name` was added in PS6; on PS5.1 it throws a parameter binding error
- Replaces the one call in `tests/Get-PlasterManifestPathForCulture.Tests.ps1` with `New-Object System.Globalization.CultureInfo("en-US")`, matching the pattern already used by the other two tests in the same file

## Test plan

- [ ] Run Pester suite on PS5.1 — `Get-PlasterManifestPathForCulture` "returns the manifest for the specified culture" passes
- [ ] Run Pester suite on PS7 — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)