### PR TITLE
fix: add PS5.1 SemanticVersion shim for consistent Resolve-ModuleVersionString return type

### DIFF
--- a/Plaster/Private/Initialize-SemanticVersion.ps1
+++ b/Plaster/Private/Initialize-SemanticVersion.ps1
@@ -1,0 +1,20 @@
+if (-not ([System.Management.Automation.PSTypeName]'System.Management.Automation.SemanticVersion').Type) {
+    Add-Type -TypeDefinition @'
+namespace System.Management.Automation {
+    public class SemanticVersion {
+        public int Major { get; private set; }
+        public int Minor { get; private set; }
+        public int Patch { get; private set; }
+        public SemanticVersion(string version) {
+            var parts = version.Split('.');
+            Major = int.Parse(parts[0]);
+            Minor = parts.Length > 1 ? int.Parse(parts[1]) : 0;
+            Patch = parts.Length > 2 ? int.Parse(parts[2]) : 0;
+        }
+        public override string ToString() {
+            return Major + "." + Minor + "." + Patch;
+        }
+    }
+}
+'@
+}

--- a/Plaster/Private/Resolve-ModuleVersionString.ps1
+++ b/Plaster/Private/Resolve-ModuleVersionString.ps1
@@ -36,17 +36,9 @@ function Resolve-ModuleVersionString {
         $VersionString = "$VersionString.0"
     }
 
-    if ($PSVersionTable.PSEdition -eq "Core") {
-        $newObjectSplat = @{
-            TypeName = "System.Management.Automation.SemanticVersion"
-            ArgumentList = $VersionString
-        }
-        return New-Object @newObjectSplat
-    } else {
-        $newObjectSplat = @{
-            TypeName = "System.Version"
-            ArgumentList = $VersionString
-        }
-        return New-Object @newObjectSplat
+    $newObjectSplat = @{
+        TypeName = "System.Management.Automation.SemanticVersion"
+        ArgumentList = $VersionString
     }
+    return New-Object @newObjectSplat
 }


### PR DESCRIPTION
Closes #460

## Summary

- `[System.Management.Automation.SemanticVersion]` is PS6+ only; on PS5.1 `Resolve-ModuleVersionString` was falling back to `[System.Version]`, causing two test assertions to fail
- Adds `Plaster/Private/Initialize-SemanticVersion.ps1`: a top-level `Add-Type` shim that defines `System.Management.Automation.SemanticVersion` in C# when the native type is absent
- Simplifies `Resolve-ModuleVersionString` to always construct `SemanticVersion` — the shim ensures the type exists on PS5.1 at module load time (alphabetical load order puts `Initialize-SemanticVersion` before `Resolve-ModuleVersionString`)
- Tests require no changes

## Test plan

- [ ] Run Pester suite on PS5.1 — both `Resolve-ModuleVersionString` tests pass
- [ ] Run Pester suite on PS7 — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)