### PR TITLE
fix: normalise xmlns attribute placement in New-PlasterManifest for PS5.1

### DIFF
--- a/Plaster/Public/New-PlasterManifest.ps1
+++ b/Plaster/Public/New-PlasterManifest.ps1
@@ -178,15 +178,23 @@ function New-PlasterManifest {
             $xmlWriterSettings.Indent = $true
             $xmlWriterSettings.NewLineOnAttributes = $true
 
+            $wroteFile = $false
             try {
                 if ($PSCmdlet.ShouldProcess($resolvedPath, $LocalizedData.ShouldCreateNewPlasterManifest)) {
                     $xmlWriter = [System.Xml.XmlWriter]::Create($resolvedPath, $xmlWriterSettings)
                     $manifest.Save($xmlWriter)
+                    $wroteFile = $true
                 }
             } finally {
                 if ($xmlWriter) {
                     $xmlWriter.Dispose()
                 }
+            }
+
+            if ($wroteFile) {
+                $content = Get-Content -Path $resolvedPath -Raw
+                $content = $content -replace '(?m)(\s+\S+="[^"]*")\s+(xmlns=)', "`$1`n  `$2"
+                Set-Content -Path $resolvedPath -Value $content -NoNewline
             }
         }
     }


### PR DESCRIPTION
Closes #461

## Summary

- PS5.1's .NET XML serializer ignores `XmlWriterSettings.NewLineOnAttributes` for namespace declarations, emitting `xmlns` inline instead of on its own indented line
- After `$xmlWriter.Dispose()`, reads the written file back and applies a regex substitution to move an inline `xmlns=` attribute onto its own line, matching the format the tests expect
- A `$wroteFile` flag gates the post-processing so it only runs when `ShouldProcess` returned true (skipped in `-WhatIf` mode)

## Test plan

- [ ] Run Pester suite on PS5.1 — all four `New-PlasterManifest` "Generates a valid manifest" tests pass
- [ ] Run Pester suite on PS7 — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)