### PR TITLE
fix: normalise AddContent path separators to forward slash on PS5.1

### DIFF
--- a/Plaster/Public/New-PlasterManifest.ps1
+++ b/Plaster/Public/New-PlasterManifest.ps1
@@ -125,8 +125,8 @@ function New-PlasterManifest {
 
                     $fileAction = [ordered]@{
                         'type'        = 'file'
-                        'source'      = $filename
-                        'destination' = $filename
+                        'source'      = $filename.Replace('\', '/')
+                        'destination' = $filename.Replace('\', '/')
                     }
                     $jsonManifest.content += $fileAction
                 }
@@ -162,11 +162,11 @@ function New-PlasterManifest {
                     $fileElem = $manifest.CreateElement('file', $TargetNamespace)
 
                     $srcAttr = $manifest.CreateAttribute("source")
-                    $srcAttr.Value = $filename
+                    $srcAttr.Value = $filename.Replace('\', '/')
                     $fileElem.Attributes.Append($srcAttr) > $null
 
                     $dstAttr = $manifest.CreateAttribute("destination")
-                    $dstAttr.Value = $filename
+                    $dstAttr.Value = $filename.Replace('\', '/')
                     $fileElem.Attributes.Append($dstAttr) > $null
 
                     $manifest.plasterManifest["content"].AppendChild($fileElem) > $null

--- a/tests/New-PlasterManifest.Tests.ps1
+++ b/tests/New-PlasterManifest.Tests.ps1
@@ -142,7 +142,7 @@ Describe 'New-PlasterManifest Command Tests' {
         }
 
         It 'AddContent parameter works' {
-            $separator = if ($IsWindows) { "\" } else { "/" }
+            $separator = "/"
             $expectedManifest = @"
 <?xml version="1.0" encoding="utf-8"?>
 <plasterManifest


### PR DESCRIPTION
## Summary

- `Get-ChildItem -Name` returns backslash-separated paths on PS5.1 Windows, causing generated manifest `source`/`destination` attributes to use `\` instead of `/`
- `New-PlasterManifest.ps1`: call `.Replace('\', '/')` on each filename before writing the `source` and `destination` attributes, in both the XML and JSON manifest paths
- `tests/New-PlasterManifest.Tests.ps1`: removes the `$IsWindows` separator branch (which evaluated to `$null`/false on PS5.1 anyway) and hardcodes `/`, matching the now-normalised output on all platforms

## Test plan

- [ ] Run Pester suite on PS5.1 — `AddContent parameter works` passes
- [ ] Run Pester suite on PS7 — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)