### PR TITLE
docs(README): Update template name in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Import-Module .\Plaster\Plaster\Plaster.psd1
 Get-PlasterTemplate
 
 # Create a new PowerShell module (interactive)
-$template = Get-PlasterTemplate | Where-Object Name -eq NewPowerShellModule
+$template = Get-PlasterTemplate | Where-Object Name -eq NewPowerShellScriptModule
 Invoke-Plaster -TemplatePath $template.TemplatePath -DestinationPath .\MyNewModule
 
 # Non-interactive with parameters


### PR DESCRIPTION
## What this changes

The Quick Start in the README shows an incorrect template name. This PR corrects the name so users can complete the Quick Start.

## Why

I tried following along with the Quick Start but failed. It was a pretty easy fix, so I did it.

## Type of change

- [ ] Bug fix (non-breaking change that corrects incorrect behavior)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Chore / refactor / documentation (no behavior change)

## Checklist

- [ ] Pester tests added or updated to cover the change
- [ ] `Invoke-psake Analyze` passes locally with no new warnings
- [ ] `Invoke-psake Test` passes locally on at least one platform
- [ ] `CHANGELOG.md` updated (required for any user-facing change)
- [x] Documentation updated ~if behavior changed~