### PR TITLE
refactor(workflow): add dispatch inputs and replace isPrerelease with force

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,29 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to publish. Leave empty to use the version in the module manifest."
+        required: false
+        type: string
+      force:
+        description: "If true, bypass the PSGallery version existence check. Use when re-triggering a failed publish job (pattern: force=true, create_release=false, publish=true)."
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: "If true, skip actual publishing and just validate the workflow logic."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release:
     uses: PowerShellOrg/.github/.github/workflows/powershell-release.yml@main
     with:
       module-name: Plaster
+      version: ${{ inputs.version || '' }}
+      force: ${{ inputs.force || false }}
+      dry_run: ${{ inputs.dry_run || false }}
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       version: ${{ inputs.version || '' }}
       force: ${{ inputs.force || false }}
       dry_run: ${{ inputs.dry_run || false }}
-      create_release: ${{ inputs.create_release != false }}
-      publish: ${{ inputs.publish != false }}
+      create_release: ${{ github.event_name != 'workflow_dispatch' || inputs.create_release }}
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,16 @@ on:
         required: false
         type: boolean
         default: false
+      create_release:
+        description: "If false, skip creating the GitHub release and tag."
+        required: false
+        type: boolean
+        default: true
+      publish:
+        description: "If false, skip publishing to PowerShell Gallery."
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -27,5 +37,7 @@ jobs:
       version: ${{ inputs.version || '' }}
       force: ${{ inputs.force || false }}
       dry_run: ${{ inputs.dry_run || false }}
+      create_release: ${{ inputs.create_release != false }}
+      publish: ${{ inputs.publish != false }}
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}


### PR DESCRIPTION
## Summary

Aligns with PowerShellOrg/.github#12.

- Adds `version`, `force`, and `dry_run` to `workflow_dispatch` inputs (previously no manual inputs were exposed)
- `force` bypasses the PSGallery existence check when re-triggering a failed job — previously there was no way to do this without a code change

## Re-trigger pattern

If `create_release` succeeds but `publish` fails (e.g. expired secret), re-trigger with:
`force=true, create_release=false, publish=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)